### PR TITLE
gradle build script fixed to download node >=v16 for apple m1/m2 cpus

### DIFF
--- a/02DependenciesAsModule/DxModule/build.gradle
+++ b/02DependenciesAsModule/DxModule/build.gradle
@@ -236,10 +236,19 @@ task deployAll(dependsOn: ['deployDxModule', 'deployAllScriptApps']){
     }
 }
 
+def getMajorVersion(String nodeVersion){
+    int pos = nodeVersion.indexOf(".")
+    return (pos>0?Integer.valueOf(nodeVersion.substring(0,pos)):0)
+}
 
 if (project.hasProperty("nodeInstall")) {
-    // Workaround node grade plugin not working on apple silicon https://github.com/node-gradle/gradle-node-plugin/issues/154
-    Boolean downloadNode = !os.isMacOsX() || arch.isAmd64()
+    // Gradle plugin's generated download URL returns 404 for new Apple CPU (M1/M2) for old node versions (<v16)
+    // https://github.com/node-gradle/gradle-node-plugin/issues/154
+    Boolean downloadNode = !os.isMacOsX() || arch.isAmd64() || getMajorVersion(project.getProperty("nodeVersion")) >= 16
+    if (!downloadNode){
+        logger.warn('Warning: Cannot download Node based on current OS, CPU architecture and Node version combination.')
+        logger.warn('   Property nodeInstall will revert to false. Gradle will use node and npm from environment path.')
+    }
     node {
         version = project.getProperty("nodeVersion")
         npmVersion = project.getProperty("npmVersion")

--- a/04AppsWithSharedDependencies/DxModule/build.gradle
+++ b/04AppsWithSharedDependencies/DxModule/build.gradle
@@ -236,10 +236,19 @@ task deployAll(dependsOn: ['deployDxModule', 'deployAllScriptApps']){
     }
 }
 
+def getMajorVersion(String nodeVersion){
+    int pos = nodeVersion.indexOf(".")
+    return (pos>0?Integer.valueOf(nodeVersion.substring(0,pos)):0)
+}
 
 if (project.hasProperty("nodeInstall")) {
-    // Workaround node grade plugin not working on apple silicon https://github.com/node-gradle/gradle-node-plugin/issues/154
-    Boolean downloadNode = !os.isMacOsX() || arch.isAmd64()
+    // Gradle plugin's generated download URL returns 404 for new Apple CPU (M1/M2) for old node versions (<v16)
+    // https://github.com/node-gradle/gradle-node-plugin/issues/154
+    Boolean downloadNode = !os.isMacOsX() || arch.isAmd64() || getMajorVersion(project.getProperty("nodeVersion")) >= 16
+    if (!downloadNode){
+        logger.warn('Warning: Cannot download Node based on current OS, CPU architecture and Node version combination.')
+        logger.warn('   Property nodeInstall will revert to false. Gradle will use node and npm from environment path.')
+    }
     node {
         version = project.getProperty("nodeVersion")
         npmVersion = project.getProperty("npmVersion")

--- a/05AppsWithDiffDepVersions/DxModule/build.gradle
+++ b/05AppsWithDiffDepVersions/DxModule/build.gradle
@@ -236,10 +236,19 @@ task deployAll(dependsOn: ['deployDxModule', 'deployAllScriptApps']){
     }
 }
 
+def getMajorVersion(String nodeVersion){
+    int pos = nodeVersion.indexOf(".")
+    return (pos>0?Integer.valueOf(nodeVersion.substring(0,pos)):0)
+}
 
 if (project.hasProperty("nodeInstall")) {
-    // Workaround node grade plugin not working on apple silicon https://github.com/node-gradle/gradle-node-plugin/issues/154
-    Boolean downloadNode = !os.isMacOsX() || arch.isAmd64()
+    // Gradle plugin's generated download URL returns 404 for new Apple CPU (M1/M2) for old node versions (<v16)
+    // https://github.com/node-gradle/gradle-node-plugin/issues/154
+    Boolean downloadNode = !os.isMacOsX() || arch.isAmd64() || getMajorVersion(project.getProperty("nodeVersion")) >= 16
+    if (!downloadNode){
+        logger.warn('Warning: Cannot download Node based on current OS, CPU architecture and Node version combination.')
+        logger.warn('   Property nodeInstall will revert to false. Gradle will use node and npm from environment path.')
+    }
     node {
         version = project.getProperty("nodeVersion")
         npmVersion = project.getProperty("npmVersion")

--- a/06ThemeComponentInApp/DxModule/build.gradle
+++ b/06ThemeComponentInApp/DxModule/build.gradle
@@ -236,10 +236,19 @@ task deployAll(dependsOn: ['deployDxModule', 'deployAllScriptApps']){
     }
 }
 
+def getMajorVersion(String nodeVersion){
+    int pos = nodeVersion.indexOf(".")
+    return (pos>0?Integer.valueOf(nodeVersion.substring(0,pos)):0)
+}
 
 if (project.hasProperty("nodeInstall")) {
-    // Workaround node grade plugin not working on apple silicon https://github.com/node-gradle/gradle-node-plugin/issues/154
-    Boolean downloadNode = !os.isMacOsX() || arch.isAmd64()
+    // Gradle plugin's generated download URL returns 404 for new Apple CPU (M1/M2) for old node versions (<v16)
+    // https://github.com/node-gradle/gradle-node-plugin/issues/154
+    Boolean downloadNode = !os.isMacOsX() || arch.isAmd64() || getMajorVersion(project.getProperty("nodeVersion")) >= 16
+    if (!downloadNode){
+        logger.warn('Warning: Cannot download Node based on current OS, CPU architecture and Node version combination.')
+        logger.warn('   Property nodeInstall will revert to false. Gradle will use node and npm from environment path.')
+    }
     node {
         version = project.getProperty("nodeVersion")
         npmVersion = project.getProperty("npmVersion")

--- a/showcase-sites/WoodBurnInsurance/DxModule/build.gradle
+++ b/showcase-sites/WoodBurnInsurance/DxModule/build.gradle
@@ -1,3 +1,19 @@
+/*
+    Copyright 2022 HCL America, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
 plugins {
     id 'ear'
     id 'war'
@@ -220,10 +236,19 @@ task deployAll(dependsOn: ['deployDxModule', 'deployAllScriptApps']){
     }
 }
 
+def getMajorVersion(String nodeVersion){
+    int pos = nodeVersion.indexOf(".")
+    return (pos>0?Integer.valueOf(nodeVersion.substring(0,pos)):0)
+}
 
 if (project.hasProperty("nodeInstall")) {
-    // Workaround node grade plugin not working on apple silicon https://github.com/node-gradle/gradle-node-plugin/issues/154
-    Boolean downloadNode = !os.isMacOsX() || arch.isAmd64()
+    // Gradle plugin's generated download URL returns 404 for new Apple CPU (M1/M2) for old node versions (<v16)
+    // https://github.com/node-gradle/gradle-node-plugin/issues/154
+    Boolean downloadNode = !os.isMacOsX() || arch.isAmd64() || getMajorVersion(project.getProperty("nodeVersion")) >= 16
+    if (!downloadNode){
+        logger.warn('Warning: Cannot download Node based on current OS, CPU architecture and Node version combination.')
+        logger.warn('   Property nodeInstall will revert to false. Gradle will use node and npm from environment path.')
+    }
     node {
         version = project.getProperty("nodeVersion")
         npmVersion = project.getProperty("npmVersion")


### PR DESCRIPTION
gradle build script fixed to download node >=v16 for apple m1/m2 cpus